### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -7,6 +7,9 @@
 
 name: Labeler
 on: [pull_request]
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   label:


### PR DESCRIPTION
Potential fix for [https://github.com/OpenISS/OpenISS/security/code-scanning/19](https://github.com/OpenISS/OpenISS/security/code-scanning/19)

To address this issue, add a `permissions` key to the workflow file `.github/workflows/label.yml`. Since this workflow triages pull requests and applies labels, the minimal permissions required are:
- `contents: read`: To read repository contents (e.g., `.github/labeler.yml` configuration).
- `pull-requests: write`: To apply labels to pull requests.

The `permissions` key should be added at the root level of the workflow, so it applies to all jobs unless overridden within individual jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
